### PR TITLE
fix(razorback): parser can parse multiple tags + ignore EOI

### DIFF
--- a/packages/razorback/src/interpreter.rs
+++ b/packages/razorback/src/interpreter.rs
@@ -110,6 +110,7 @@ impl Interpreter {
 
                 Ok(Some(Value::Object(result)))
             }
+            Node::EOI() => Ok(None),
             value => unimplemented!("{:?}", value),
         }
     }

--- a/packages/razorback/src/parser.rs
+++ b/packages/razorback/src/parser.rs
@@ -3,7 +3,7 @@ use pest::error::Error;
 use pest::{iterators::Pair, Parser};
 
 pub fn parse_to_node(script: &str) -> Result<Node, Error<Rule>> {
-    let value = Node::parse(Rule::value, script).unwrap();
+    let value = Node::parse(Rule::script, script).unwrap();
     let value = Node::Value(value.map(parse_pair).collect());
     Ok(value)
 }
@@ -73,6 +73,8 @@ fn parse_pair(pair: Pair<Rule>) -> Node {
                 Node::Integer(pair.as_str().parse().unwrap())
             }
         }
+        Rule::script => Node::Value(pair.into_inner().map(parse_pair).collect()),
+        Rule::EOI => Node::EOI(),
         _ => unreachable!("Unknown rule {:?}", pair.as_rule()),
     }
 }

--- a/packages/razorback/src/types/node.rs
+++ b/packages/razorback/src/types/node.rs
@@ -21,4 +21,5 @@ pub enum Node<'a> {
     Reference(&'a str),
     Array(Vec<Node<'a>>),
     Object(Vec<(&'a str, Node<'a>)>),
+    EOI(),
 }


### PR DESCRIPTION
Currently, razorback can only parse one tag, since the parser is parsing the script as a `Rule::value` and not as `Rule::script`

This PR fixes this issue, allowing for every tag to be parsed