### PR TITLE
fix(razorback): make newline after comment optional

### DIFF
--- a/packages/razorback/src/razorback.pest
+++ b/packages/razorback/src/razorback.pest
@@ -1,6 +1,6 @@
 WHITESPACE    = _{ " " | "\t" | NEWLINE }
 COMMENT       = _{ COMMENT_LINE | COMMENT_BLOCK }
-COMMENT_LINE  = _{ "//" ~ (!NEWLINE ~ ANY)* ~ NEWLINE }
+COMMENT_LINE  = _{ "//" ~ (!NEWLINE ~ ANY)* ~ NEWLINE? }
 COMMENT_BLOCK = _{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
 
 script = _{ SOI ~ (tag | outer)* ~ EOI }


### PR DESCRIPTION
Currently, if there is no newline after a comment, razorback panics and gives up, which would require a newline after a comment.

```razorback
{=myvar "cool variable"}
// A comment
```

it panics, because it thinks there should be a new line after the comment